### PR TITLE
Fixed "delete too much" bug on card #

### DIFF
--- a/TypeYourCard/TypeCardScene/TypeCardEnvironment.swift
+++ b/TypeYourCard/TypeCardScene/TypeCardEnvironment.swift
@@ -111,7 +111,6 @@ fileprivate extension TypeCardEnvironment {
         var tempNumb = number
         
         if oldValue == "\(tempNumb) " {
-            tempNumb.removeLast(2)
             number = tempNumb
         } else {
             var resultStr = ""


### PR DESCRIPTION
This was creating the following odd behavior where 2 numbers where removed whenever the user cleared a "group" when deleting numbers:
![original](https://user-images.githubusercontent.com/714458/60643179-211bff80-9de7-11e9-9cd7-123f50adce57.gif)

Now it looks like this:
![fixed](https://user-images.githubusercontent.com/714458/60643203-28430d80-9de7-11e9-8cb8-36164723de43.gif)

