### PR TITLE
PayCardField enum changes

### DIFF
--- a/TypeYourCard/Models/PayCardField.swift
+++ b/TypeYourCard/Models/PayCardField.swift
@@ -7,8 +7,7 @@
 //
 import SwiftUI
 
-enum PayCardField: Int, CaseIterable {
-    // Int - is input order
+enum PayCardField: CaseIterable {
     case number
     case holder
     case validThru

--- a/TypeYourCard/Swift+/String+.swift
+++ b/TypeYourCard/Swift+/String+.swift
@@ -29,3 +29,19 @@ extension String {
         return String(self[idx1..<idx2])
     }
 }
+
+extension Collection where Iterator.Element: Equatable {
+    func after(_ element: Element) -> Element? {
+        if let elementIndex = self.firstIndex(of: element), elementIndex < self.endIndex {
+            return self[index(after: elementIndex)]
+        }
+        return nil
+    }
+    
+    func before(_ element: Element) -> Element? {
+        if let elementIndex = self.firstIndex(of: element), elementIndex > self.startIndex {
+            return self[index(elementIndex, offsetBy: -1)]
+        }
+        return nil
+    }
+}

--- a/TypeYourCard/TypeCardScene/TypeCardScene.swift
+++ b/TypeYourCard/TypeCardScene/TypeCardScene.swift
@@ -23,11 +23,11 @@ extension PayCardField {
     }
     
     var nextForInput: PayCardField? {
-        PayCardField(rawValue: rawValue + 1)
+        PayCardField.allCases.after(self)
     }
     
     var prevForInput: PayCardField? {
-        PayCardField(rawValue: rawValue - 1)
+        PayCardField.allCases.before(self)
     }
 }
 

--- a/TypeYourCard/TypeCardScene/TypeCardScene.swift
+++ b/TypeYourCard/TypeCardScene/TypeCardScene.swift
@@ -11,11 +11,11 @@ import SwiftUI
 extension PayCardField {
     
     var isFirstInput: Bool {
-        self.rawValue == PayCardField.allCases.map { $0.rawValue }.min()!
+        self == PayCardField.allCases.first
     }
     
     var isLastInput: Bool {
-        self.rawValue == PayCardField.allCases.map { $0.rawValue }.max()!
+        self == PayCardField.allCases.last
     }
     
     var buttonTitle: String {


### PR DESCRIPTION
*Short*
I'm removing the requirement of `PayCardField` being an Int and simplifying the code associated to it.

*Description*
By re implementing the computed properties `isFirstInput`, `isLastInput`, `nextForInput` and `prevForInput` with simpler versions that rely solely in methods from the `allCases` Array now there is no need for the enum to have a RawValue of `Int`.

The order of the fields is now regulated by the `PayCardField` itself, change the order of the cases inside it and it will change the order of the fields in the app, there is no confusion nor future bugs if someone gives an explicit rawValue to one of the cases (example: `case number = 1; case holder = 0`) Change the order of the lines and it changes the logical order of the fields in the app.

On `isFirstInput` and `isLastInput` I'm now using the methods `first` and `last` from Array to check, instead of doing the `map` approach that could be hard to read.

On nextForInput` and `prevForInput` I introduced an extension over Collections so we can easily request for the next or previous elements in an array given an element simplifying the code, this changes does not introduce any obvious simplification or readability improvement to the code but is a must in order to completely remove the requirement of `PayCardField` having a RawValue, that way the order of the fields is only determined by the order of the cases in the enum definition.
